### PR TITLE
Hotfix/issues client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'popper_js', '~> 1.14'
 # Javascript framework used in bootstrap
 gem 'jquery-rails'
 gem 'jquery-datatables'
+gem 'rails-autocomplete'
 # gem for datatables excel export
 gem 'jszip-rails', '~> 2.5'
 gem 'sweetalert-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.2)
       sprockets-rails (>= 2.0.0)
+    rails-autocomplete (2.0.1)
+      rails (>= 4.0)
     rails-controller-testing (1.0.4)
       actionpack (>= 5.0.1.x)
       actionview (>= 5.0.1.x)
@@ -311,6 +313,7 @@ GEM
     uber (0.1.0)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    wdm (0.1.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -351,6 +354,7 @@ DEPENDENCIES
   popper_js (~> 1.14)
   puma (~> 3.11)
   rails (~> 5.2.1)
+  rails-autocomplete
   rails-controller-testing
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
@@ -362,6 +366,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  wdm (>= 0.1.0)
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,8 +14,9 @@
 //= require activestorage
 //= require turbolinks
 //= require jquery3
-//= require jquery-ui
 //= require jquery_ujs
+//= require jquery-ui
+//= require autocomplete-rails
 //= require popper
 //= require bootstrap-sprockets
 //= require jszip

--- a/app/assets/javascripts/expenses.js
+++ b/app/assets/javascripts/expenses.js
@@ -132,4 +132,3 @@ function addExpenseNamesPreview(names, element){
     );
   }
 }
-//= require jquery

--- a/app/assets/javascripts/expenses.js
+++ b/app/assets/javascripts/expenses.js
@@ -1,9 +1,3 @@
-jQuery(function() {
-    return $('#expense_supplier_name').autocomplete({
-        source: $('#expense_supplier_name').data('autocomplete-source')
-    });
-});
-
 // Expenses
 $( document ).on('ready turbolinks:load', function() {
     $('#expenses-datatable tbody').on('click', 'button.delete-expense-ajax', function (e) {
@@ -138,3 +132,4 @@ function addExpenseNamesPreview(names, element){
     );
   }
 }
+//= require jquery

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -48,6 +48,7 @@ class BlogsController < ApplicationController
     @required_str = ""
     @concepts = @project.concepts.order(:code)
     @has_concepts_jobs = @concepts.joins(:jobs).any?
+    @column_size = "col-md-12 mT-15"
 
     #Check privileges to retrieve jobs and expenses
     if has_privilege(current_user, 'job_prog_7')
@@ -70,6 +71,7 @@ class BlogsController < ApplicationController
     @blog = @project.blogs.new
     @blog.date = Time.now
     @blog.status = false
+    @column_size = "col-md-6 mT-15"
   end
 
   def create
@@ -90,6 +92,7 @@ class BlogsController < ApplicationController
     @readonly = false
     @create = false
     @required_str = "* "
+    @column_size = "col-md-6 mT-15"
   end
 
   def update

--- a/app/controllers/email_resets_controller.rb
+++ b/app/controllers/email_resets_controller.rb
@@ -21,6 +21,9 @@ class EmailResetsController < ApplicationController
   end
 
   def edit_password
+    if current_user.present?
+      log_out
+    end
   end
 
   def update_password

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,5 +1,7 @@
 class ExpensesController < ApplicationController
 
+  autocomplete :supplier, :name
+
   #RBAC show
   before_action only: [:index, :show] do
     has_privilege_controller(current_user, 'expenses_1')

--- a/app/views/blogs/_form.html.erb
+++ b/app/views/blogs/_form.html.erb
@@ -42,9 +42,21 @@
                             readonly: @readonly %>
           </div>
 
-          <% if has_privilege(current_user, "blog_6") %>
-            <% if !@readonly %>
-              <% if has_privilege(current_user, "blog_5") or @create%>
+          <% if !@create %>
+            <% if has_privilege(current_user, "blog_6") %>
+              <% if !@readonly %>
+                <% if has_privilege(current_user, "blog_5")%>
+                  <div class=<%= @column_size %>>
+                    <%= f.label :status, "Estado de Aprobación: " %>
+                    <br>
+                    <label class="switch">
+                      <% @readonly ? @var = "return false;" : @var = ""%>
+                      <%= f.check_box :status, onclick: @var %>
+                      <span class="slider round"></span>
+                    </label>
+                  </div>
+                 <% end %>
+               <% else %>
                 <div class=<%= @column_size %>>
                   <%= f.label :status, "Estado de Aprobación: " %>
                   <br>
@@ -55,19 +67,10 @@
                   </label>
                 </div>
                <% end %>
-             <% else %>
-              <div class=<%= @column_size %>>
-                <%= f.label :status, "Estado de Aprobación: " %>
-                <br>
-                <label class="switch">
-                  <% @readonly ? @var = "return false;" : @var = ""%>
-                  <%= f.check_box :status, onclick: @var %>
-                  <span class="slider round"></span>
-                </label>
-              </div>
              <% end %>
-           <% end %>
+          <% end %>
         </div>
+
   <% if !@readonly %>
     <div id="form-footer-blog">
       <hr>

--- a/app/views/blogs/_form.html.erb
+++ b/app/views/blogs/_form.html.erb
@@ -6,7 +6,7 @@
               <p>Los campos marcados con '*' son obligatorios.</p>
             </div>
           <% end %>
-          <div class="col-md-12">
+          <div class=<%= @column_size %>>
             <%= f.label :date, "#{@required_str}Fecha de la bitácora: " %>
             <%= f.text_field :date,
                              class: 'form-control datepicker',
@@ -15,7 +15,7 @@
                              :value => @blog.date.strftime('%d/%m/%Y'),
                              readonly: @readonly %>
           </div>
-          <div class="col-md-12 mT-15">
+          <div class=<%= @column_size %>>
             <%= f.label :name, "#{@required_str}Nombre de la bitácora:" %>
             <%= f.text_field :name,
                              class:"form-control",
@@ -23,7 +23,7 @@
                              placeholder: "e.g. Bitácora B12",
                              readonly: @readonly %>
           </div>
-          <div class="col-md-12 mT-15">
+          <div class=<%= @column_size %>>
             <%= f.label :description, "Descripción: " %>
             <%= f.text_area :description,
                              class: 'form-control',
@@ -32,7 +32,7 @@
                              rows: 3,
                              readonly: @readonly %>
           </div>
-          <div class="col-md-12 mT-15">
+          <div class=<%= @column_size %>>
             <%= f.label :comments, "Comentarios: " %>
             <%= f.text_area :comments,
                             class: 'form-control',
@@ -45,7 +45,7 @@
           <% if has_privilege(current_user, "blog_6") %>
             <% if !@readonly %>
               <% if has_privilege(current_user, "blog_5") or @create%>
-                <div class="col-md-12 mT-15">
+                <div class=<%= @column_size %>>
                   <%= f.label :status, "Estado de Aprobación: " %>
                   <br>
                   <label class="switch">
@@ -56,7 +56,7 @@
                 </div>
                <% end %>
              <% else %>
-              <div class="col-md-12 mT-15">
+              <div class=<%= @column_size %>>
                 <%= f.label :status, "Estado de Aprobación: " %>
                 <br>
                 <label class="switch">

--- a/app/views/concepts/_form.html.erb
+++ b/app/views/concepts/_form.html.erb
@@ -5,17 +5,17 @@
         <p>Los campos marcados con '*' son obligatorios. </p>
       </div>
     <% end %>
-    <div class="col-md-12 mT-15">
+    <div class="col-md-6 mT-15">
       <%= f.label :code, "#{@required_str}Clave:" %>
       <%= f.text_field :code, class:"form-control", required: 'true', placeholder: "e.g. PRE001", :maxlength => 6, readonly: @read_only %>
     </div>
-    <div class="col-md-12 mT-15">
+    <div class="col-md-6 mT-15">
       <%= f.label :category_id, "#{@required_str}Categoría del gasto:" %>
       <%= f.select(:category_id, options_for_select(@categories.map{|s|[s.name, s.id]}, @category_id),
                      {:include_blank => 'Seleccione una categoría'},
                      {:class => 'form-control', :required => 'true', :disabled => @read_only}) %>
     </div>
-    <div class="col-md-12 mT-15">
+    <div class="col-md-6 mT-15">
       <%= f.label :description, "#{@required_str}Descripción:" %>
       <%= f.text_area :description,
                       class: 'form-control',
@@ -25,7 +25,7 @@
                       required: true,
                       readonly: @read_only%>
     </div>
-    <div class="col-md-12 mT-15">
+    <div class="col-md-6 mT-15">
       <%= f.label :quantity, "#{@required_str}Cantidad:" %>
       <%= f.number_field :quantity, 
         class: 'form-control', 
@@ -34,7 +34,7 @@
         step: 0.001,
         readonly: @read_only %>
     </div>
-    <div class="col-md-12 mT-15">
+    <div class="col-md-6 mT-15">
       <%= f.label :unity, "#{@required_str}Unidad:" %>
       <%= f.text_field :unity, 
         class:"form-control", 
@@ -42,7 +42,7 @@
         placeholder: "e.g. m2", 
         readonly: @read_only %>
     </div>
-    <div class="col-md-12 mT-15">
+    <div class="col-md-6 mT-15">
       <%= f.label :unit_price, "#{@required_str}Precio por Unidad:" %>
       <%= f.number_field :unit_price, 
         class:"form-control", 
@@ -51,7 +51,7 @@
         step: 0.001,
         readonly: @read_only %>
     </div>
-    <div class="col-md-12 mT-15">
+    <div class="col-md-6 mT-15">
       <%= f.label :weight, "#{@required_str}Peso:" %>
       <%= f.number_field :weight,
                          class:"form-control",

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -65,9 +65,24 @@
               readonly: @read_only %>
           </div>
 
-          <% if has_privilege(current_user, "expenses_7") %>
-            <% if !@read_only %>
-              <% if has_privilege(current_user, "expenses_5") or @create%>
+          <% if !@create %>
+            <% if has_privilege(current_user, "expenses_7") %>
+              <% if !@read_only %>
+                <% if has_privilege(current_user, "expenses_5")%>
+                  <div class="col-md-6 mT-15">
+                    <label for = "user_status">Aprobado:</label>
+                    <div class="row">
+                      <div class="col-md-2 col-sm-2" align="center">
+                        <label class="switch">
+                          <% @read_only ? @var = "return false;" : @var = ""%>
+                          <%= f.check_box :status, onclick: @var %>
+                          <span class="slider round"></span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                <% end %>
+              <% else %>
                 <div class="col-md-6 mT-15">
                   <label for = "user_status">Aprobado:</label>
                   <div class="row">
@@ -81,25 +96,25 @@
                   </div>
                 </div>
               <% end %>
-            <% else %>
-              <div class="col-md-6 mT-15">
-                <label for = "user_status">Aprobado:</label>
-                <div class="row">
-                  <div class="col-md-2 col-sm-2" align="center">
-                    <label class="switch">
-                      <% @read_only ? @var = "return false;" : @var = ""%>
-                      <%= f.check_box :status, onclick: @var %>
-                      <span class="slider round"></span>
-                    </label>
-                  </div>
-                </div>
-              </div>
             <% end %>
-          <% end %>
 
-          <% if has_privilege(current_user, "expenses_8") %>
-            <% if !@read_only %>
-              <% if has_privilege(current_user, "expenses_6") or @create%>
+            <% if has_privilege(current_user, "expenses_8") %>
+              <% if !@read_only %>
+                <% if has_privilege(current_user, "expenses_6")%>
+                  <div class="col-md-6 mT-15">
+                    <label>Facturado:</label>
+                    <div class="row">
+                      <div class="col-md-2 col-sm-2" align="center">
+                        <label class="switch">
+                          <% @read_only ? @var = "return false;" : @var = ""%>
+                          <%= f.check_box :status_ticket, onclick: @var %>
+                          <span class="slider round"></span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                <% end %>
+              <% else %>
                 <div class="col-md-6 mT-15">
                   <label>Facturado:</label>
                   <div class="row">
@@ -113,19 +128,6 @@
                   </div>
                 </div>
               <% end %>
-            <% else %>
-              <div class="col-md-6 mT-15">
-                <label>Facturado:</label>
-                <div class="row">
-                  <div class="col-md-2 col-sm-2" align="center">
-                    <label class="switch">
-                      <% @read_only ? @var = "return false;" : @var = ""%>
-                      <%= f.check_box :status_ticket, onclick: @var %>
-                      <span class="slider round"></span>
-                    </label>
-                  </div>
-                </div>
-              </div>
             <% end %>
           <% end %>
 

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -15,7 +15,7 @@
 
           <div class="col-md-6 mT-15">
             <%= f.label :supplier_name, "#{@required_str}Nombre del proveedor:" %>
-            <%= f.text_field :supplier_name, class:"form-control", required: 'true', placeholder: "e.g. Azupiso", data: { autocomplete_source: suppliers_path}, readonly: @read_only %>
+            <%= f.autocomplete_field :supplier_name, autocomplete_supplier_name_project_blog_expenses_path, class:"form-control", required: 'true', placeholder: "e.g. Azupiso", readonly: @read_only %>
           </div>
 
           <div class="col-md-6 mT-15">

--- a/app/views/job_progresses/_index.html.erb
+++ b/app/views/job_progresses/_index.html.erb
@@ -44,11 +44,11 @@
       <tbody>
       <% @job_progress.each do |job_progress| %>
         <tr>
-          <td>
-            <% if has_privilege(current_user, "concept_1") %>
-            <%= link_to job_progress.job.concept.code, {:controller => :concepts, :action => :show, :id => job_progress.job.concept.id} %>
-            <% end %>
-          </td>
+          <% if has_privilege(current_user, "concept_1") %>
+            <td>
+              <%= link_to job_progress.job.concept.code, {:controller => :concepts, :action => :show, :id => job_progress.job.concept.id} %>
+            </td>
+          <% end %>
           <td><%= job_progress.job.name %></td>
           <td><%= number_with_delimiter(job_progress.quantity) %> <%= job_progress.job.unity %></td>
           <% if has_privilege(current_user, "job_prog_5") || has_privilege(current_user, "job_prog_6") %>

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -1,4 +1,3 @@
-
 <%= form_for [@project, @concept, @job] do |f| %>
   <%= render 'layouts/errors_form', object: @job %>
   <div class="modal-body">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -44,9 +44,6 @@
                              placeholder: "e.g. 1234567",
                              readonly: @readonly %>
           </div>
-        </div>
-
-        <div class="row">
           <div class="col-md-6 mT-15">
             <%= f.label :email, "#{@required_str}Correo electrónico: " %>
             <%= f.email_field :email,
@@ -55,13 +52,26 @@
                               placeholder: "e.g. gama@mail.com",
                               readonly: @readonly %>
           </div>
-        </div>
 
-        <div class="row">
 
-          <% if has_privilege(current_user, "user_6") %>
-            <% if !@readonly %>
-              <% if has_privilege(current_user, "user_5") or @create%>
+          <% if !@create %>
+            <% if has_privilege(current_user, "user_6") %>
+              <% if !@readonly %>
+                <% if has_privilege(current_user, "user_5")%>
+                  <div class="col-md-6 mT-15">
+                    <label for = "user_status">Estado en el sistema:</label>
+                    <div class="row">
+                      <div class="col-md-2 col-sm-2" align="center">
+                        <label class="switch">
+                          <% @readonly ? @var = "return false;" : @var = ""%>
+                          <%= f.check_box :status, onclick: @var %>
+                          <span class="slider round"></span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                <% end %>
+              <% else %>
                 <div class="col-md-6 mT-15">
                   <label for = "user_status">Estado en el sistema:</label>
                   <div class="row">
@@ -75,19 +85,6 @@
                   </div>
                 </div>
               <% end %>
-            <% else %>
-              <div class="col-md-6 mT-15">
-                <label for = "user_status">Estado en el sistema:</label>
-                <div class="row">
-                  <div class="col-md-2 col-sm-2" align="center">
-                    <label class="switch">
-                      <% @readonly ? @var = "return false;" : @var = ""%>
-                      <%= f.check_box :status, onclick: @var %>
-                      <span class="slider round"></span>
-                    </label>
-                  </div>
-                </div>
-              </div>
             <% end %>
           <% end %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: utf8
   pool: 5
-  password: Avenged10jc
+  password: admin
   port: 5432
   username: postgres
   host: localhost

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
       get  'jobs/:job_id/job_progresses/new',  to: 'job_progresses#new', as: :new_job_progresses
       # expenses
       resources :expenses do
+        get :autocomplete_supplier_name, :on => :collection
         member do
           get 'edit_image_info/:attachment_id', to: 'expenses#edit_image_info', as: :edit_expense_image_info
           patch 'update_image_info/:attachment_id', to: 'expenses#update_image_info', as: :update_expense_image_info
@@ -78,9 +79,6 @@ Rails.application.routes.draw do
 
   #ajax routes for job progresses in blogs
   post 'job_progresses/activate', to: 'job_progresses#activate', as: :activate_job_progresses
-
-  # suppliers
-  resources :suppliers
 
   # roles
   resources :roles

--- a/db/migrate/20190318182200_change_status_default_in_tables.rb
+++ b/db/migrate/20190318182200_change_status_default_in_tables.rb
@@ -1,0 +1,5 @@
+class ChangeStatusDefaultInTables < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :blogs, :status, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_21_154950) do
+ActiveRecord::Schema.define(version: 2019_03_18_182200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2019_02_21_154950) do
   create_table "blogs", force: :cascade do |t|
     t.string "name", limit: 256, null: false
     t.string "description", limit: 1024, null: false
-    t.boolean "status", default: true, null: false
+    t.boolean "status", default: false, null: false
     t.date "date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds/development/roleprivileges.rb
+++ b/db/seeds/development/roleprivileges.rb
@@ -482,19 +482,7 @@ if !Roleprivilege.find_by(role_id: 1)
                                               },
                                               {
                                                   role_id: 3,
-                                                  privilege_id: 27
-                                              },
-                                              {
-                                                  role_id: 3,
                                                   privilege_id: 28
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 29
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 30
                                               },
                                               {
                                                   role_id: 3,
@@ -507,18 +495,6 @@ if !Roleprivilege.find_by(role_id: 1)
                                               {
                                                   role_id: 3,
                                                   privilege_id: 34
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 36
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 37
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 38
                                               },
                                               {
                                                   role_id: 3,
@@ -542,26 +518,6 @@ if !Roleprivilege.find_by(role_id: 1)
                                               },
                                               {
                                                   role_id: 3,
-                                                  privilege_id: 47
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 48
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 49
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 50
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 52
-                                              },
-                                              {
-                                                  role_id: 3,
                                                   privilege_id: 55
                                               },
                                               {
@@ -575,14 +531,6 @@ if !Roleprivilege.find_by(role_id: 1)
                                               {
                                                   role_id: 3,
                                                   privilege_id: 59
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 60
-                                              },
-                                              {
-                                                  role_id: 3,
-                                                  privilege_id: 61
                                               },
                                               {
                                                   role_id: 3,


### PR DESCRIPTION
Fixed issues:

- 6: Al dar clic en correo de cambio de contraseña, se queda abierta la sesión anterior.
- 8: Quitar botones de status (validar privilegio de aprovar) de formas (por lo menos crear), de usuario, bitacoras, gastos, proyectos, etc. (Default en bitácoras y gastos como no aprobado).
- 13: Autocompletar de proveedores al registrar gasto no funciona.
- 14: Columnas en formas (6 por campo en lugar de 12) conceptos y bitácoras.